### PR TITLE
Utilizando o pydantic para gerenciamento de configurações

### DIFF
--- a/controller/private_api.py
+++ b/controller/private_api.py
@@ -1,17 +1,16 @@
 from http.client import HTTPException
 from urllib.request import Request
+
+from core import settings
 from fastapi import FastAPI
-from dotenv import dotenv_values
-from starlette.responses import JSONResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
 from model.streamer_model import Streamer
+from starlette.responses import JSONResponse
 from view_model.streamer_viewmodel import StreamerViewModel
-
 
 origins = ["*"]
 
 
-config = dotenv_values(".env")
 app_private = FastAPI(openapi_prefix="/api")
 
 app_private.add_middleware(
@@ -25,7 +24,7 @@ app_private.add_middleware(
 @app_private.middleware("http")
 async def verify_user_agent(request: Request, call_next):
     try:
-        if request.headers['token'] == config['API_TOKEN']:
+        if request.headers["token"] == settings.API_TOKEN:
             response = await call_next(request)
             return response
     except Exception as e:

--- a/controller/public_api.py
+++ b/controller/public_api.py
@@ -1,10 +1,7 @@
 from fastapi import FastAPI
-from model.stat_model import Stat
-from service.stats_service import get_stats, get_stats_summary, compute_stat
-from service.streamer_service import get_streamers, get_vods
 from fastapi.middleware.cors import CORSMiddleware
-from model.streamer_model import Streamer
-
+from service.stats_service import compute_stat, get_stats, get_stats_summary
+from service.streamer_service import get_streamers, get_vods
 from view_model.stat_viewmodel import StatViewModel
 
 origins = ["*"]

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,3 @@
+from .settings import Settings
+
+settings = Settings()

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    ENV: str = "dev"
+    API_TOKEN: str
+
+    # Twitch settings.
+    CLIENT_ID: str
+    CLIENT_SECRET: str
+
+    # Twitter settings.
+    TWITTER_API_KEY: str
+    TWITTER_API_SECRET: str
+    TWITTER_ACCESS_TOKEN: str
+    TWITTER_ACCESS_SECRET: str
+
+    # GitHub settings.
+    GITHUB_TOKEN: str
+
+    # Production only.
+    CERT: Optional[str]
+    PRIVATE_KEY: Optional[str]
+
+    # The database location
+    DB: str = ""

--- a/core/settings.py
+++ b/core/settings.py
@@ -26,3 +26,7 @@ class Settings(BaseSettings):
 
     # The database location
     DB: str = ""
+
+    class Config:
+        case_sensitive = True
+        env_file = ".env"

--- a/main.py
+++ b/main.py
@@ -1,15 +1,12 @@
-
-from model.initializer import init_db, migrate_db
-from dotenv import dotenv_values
+import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-import uvicorn
-from controller.public_api import app_public
+
 from controller.private_api import app_private
-
+from controller.public_api import app_public
+from core import settings
+from model.initializer import init_db, migrate_db
 from view_model.streamer_viewmodel import StreamerViewModel
-
-config = dotenv_values(".env")
 
 init_db()
 migrate_db()
@@ -30,15 +27,16 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-if __name__ == '__main__':
-    if(config["ENV"] == 'prod'):
-        uvicorn.run("main:app",
-                    host="0.0.0.0",
-                    port=8000,
-                    reload=True,
-                    ssl_keyfile=config["PRIVATE_KEY"],
-                    ssl_certfile=config["CERT"]
-                    )
+if __name__ == "__main__":
+    if settings.ENV == "prod":
+        uvicorn.run(
+            "main:app",
+            host="0.0.0.0",
+            port=8000,
+            reload=True,
+            ssl_keyfile=settings.PRIVATE_KEY,
+            ssl_certfile=settings.CERT,
+        )
     else:
         uvicorn.run("main:app",
                     host="0.0.0.0",

--- a/model/initializer.py
+++ b/model/initializer.py
@@ -1,11 +1,12 @@
+from core import settings
 from peewee import *
-from model.streamer_model import Streamer
-from model.stat_model import Stat
-from dotenv import dotenv_values
-from playhouse.migrate import * 
+from playhouse.migrate import *
 
-config = dotenv_values(".env")
-db = SqliteDatabase(config["DB"] + "brdevstreamers.db")
+from model.stat_model import Stat
+from model.streamer_model import Streamer
+
+db = SqliteDatabase(settings.DB + "brdevstreamers.db")
+
 
 def init_db():   
     db.connect()

--- a/model/stat_model.py
+++ b/model/stat_model.py
@@ -1,9 +1,8 @@
-from enum import unique
+from core import settings
 from peewee import *
-from dotenv import dotenv_values
-config = dotenv_values(".env")
 
-db = SqliteDatabase(config["DB"] + "brdevstreamers.db")
+db = SqliteDatabase(settings.DB + "brdevstreamers.db")
+
 
 class Stat(Model):
     user_login = CharField(null=False)

--- a/model/streamer_model.py
+++ b/model/streamer_model.py
@@ -1,9 +1,10 @@
 from enum import unique
-from peewee import *
-from dotenv import dotenv_values
-config = dotenv_values(".env")
 
-db = SqliteDatabase(config["DB"] + "brdevstreamers.db")
+from core import settings
+from peewee import *
+
+db = SqliteDatabase(settings.DB + "brdevstreamers.db")
+
 
 class Streamer(Model):
     user_id = CharField(unique=True)

--- a/poc.py
+++ b/poc.py
@@ -1,9 +1,8 @@
 from twitchAPI.twitch import Twitch
-from dotenv import dotenv_values
-config = dotenv_values(".env")
 
+from core import settings
 
-twitch = Twitch(config['CLIENT_ID'], config['CLIENT_SECRET'])
+twitch = Twitch(settings.CLIENT_ID, settings.CLIENT_SECRET)
 
 users = twitch.get_users(user_ids=['227168488'])
 

--- a/service/github_service.py
+++ b/service/github_service.py
@@ -1,13 +1,13 @@
+from core import settings
 from github import Github
-from dotenv import dotenv_values
 
-config = dotenv_values(".env")
 user_githubs = {}
+
 
 def has_github_account(username):
     try:
         if username not in user_githubs:
-            g = Github(config["GITHUB_TOKEN"])
+            g = Github(settings.GITHUB_TOKEN)
             user = g.get_user(username)
             user_githubs[username] = True
     except:

--- a/service/stats_service.py
+++ b/service/stats_service.py
@@ -1,9 +1,8 @@
+from core import settings
 from model.stat_model import Stat
 from peewee import *
-from dotenv import dotenv_values
-config = dotenv_values(".env")
 
-db = SqliteDatabase(config["DB"] + "brdevstreamers.db")
+db = SqliteDatabase(settings.DB + "brdevstreamers.db")
 
 def get_stats():
     cursor = db.execute_sql(

--- a/service/streamer_service.py
+++ b/service/streamer_service.py
@@ -1,12 +1,10 @@
-from twitchAPI.twitch import Twitch
-from dotenv import dotenv_values
+from core import settings
 from model.streamer_model import Streamer
-from service.github_service import has_github_account
+from twitchAPI.twitch import Twitch
 from twitchAPI.types import TimePeriod
-from service.twitter_service import has_twitter_account
 
-config = dotenv_values(".env")
-twitch = Twitch(config['CLIENT_ID'], config['CLIENT_SECRET'])
+twitch = Twitch(settings.CLIENT_ID, settings.CLIENT_SECRET)
+
 
 def get_streamers():
     games = twitch.get_games(names=['Software and Game Development'])

--- a/service/twitter_service.py
+++ b/service/twitter_service.py
@@ -1,13 +1,14 @@
+from core import settings
 from twitter import *
-from dotenv import dotenv_values
 
-config = dotenv_values(".env")
 t = Twitter(
     auth=OAuth(
-        config['TWITTER_ACCESS_TOKEN'], 
-        config['TWITTER_ACCESS_SECRET'],
-        config['TWITTER_API_KEY'], 
-        config['TWITTER_API_SECRET']))
+        settings.TWITTER_ACCESS_TOKEN,
+        settings.TWITTER_ACCESS_SECRET,
+        settings.TWITTER_API_KEY,
+        settings.TWITTER_API_SECRET,
+    )
+)
 
 user_twitters = {}
 

--- a/view_model/stat_viewmodel.py
+++ b/view_model/stat_viewmodel.py
@@ -1,6 +1,5 @@
-from typing import Optional
-from xmlrpc.client import DateTime
 from datetime import datetime
+
 from pydantic import BaseModel
 
 


### PR DESCRIPTION
closes #2 

Este PR tem o objetivo de remover a dependência `python-dotenv` em benefício do gerenciamento de configurações do próprio Pydantic (dependência do FastAPI). Quando executado o `python main.py` sem especificar as variáveis de ambiente obrigatória, esse erro será exibido e impedirá a inicialização do app:

```sh
pydantic.error_wrappers.ValidationError: 8 validation errors for Settings
API_TOKEN
  field required (type=value_error.missing)
CLIENT_ID
  field required (type=value_error.missing)
CLIENT_SECRET
  field required (type=value_error.missing)
TWITTER_API_KEY
  field required (type=value_error.missing)
TWITTER_API_SECRET
  field required (type=value_error.missing)
TWITTER_ACCESS_TOKEN
  field required (type=value_error.missing)
TWITTER_ACCESS_SECRET
  field required (type=value_error.missing)
GITHUB_TOKEN
  field required (type=value_error.missing)
```